### PR TITLE
chore: opt out of Renovate automerge (no CI)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>eddgrant/renovate-config"]
+  "extends": ["github>eddgrant/renovate-config"],
+  "packageRules": [
+    {
+      "description": "No CI in this repo, so Renovate updates are unverified — never automerge here.",
+      "matchPackageNames": ["*"],
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
The shared `renovate-config` preset now automerges non-major updates once CI passes (eddgrant/renovate-config#2). This repo has **no CI**, so automerge would merge unverified changes. This adds an `automerge: false` packageRule to opt out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)